### PR TITLE
Carry relay X-Error-Details on GlowNetworkError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glow.ts",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glow.ts",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "async-mutex": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glow.ts",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "displayName": "Glow.ts",
   "description": "Client library for interacting with Zax Cryptographic Relay Servers",
   "keywords": [

--- a/src/relay/network-error.ts
+++ b/src/relay/network-error.ts
@@ -1,7 +1,14 @@
 export class GlowNetworkError extends Error {
   readonly name = 'GlowNetworkError';
 
-  constructor(public status: number|undefined) {
-    super(`GlowNetworkError status: ${status}`);
+  /**
+   * @param status HTTP status code, 0 for network-layer failures, 408 for timeouts
+   * @param details relay-provided reason from the `X-Error-Details` response header.
+   * Most relay rejections share one generic text on purpose; conditions the relay
+   * considers safe to reveal (e.g. a full mailbox or an exceeded storage quota)
+   * carry a specific message the caller can branch on.
+   */
+  constructor(public status: number|undefined, public details?: string) {
+    super(details ? `GlowNetworkError status: ${status} (${details})` : `GlowNetworkError status: ${status}`);
   }
 }

--- a/src/relay/relay.spec.ts
+++ b/src/relay/relay.spec.ts
@@ -21,4 +21,36 @@ describe('Relay', () => {
     const connection = relay.openConnection();
     expect(connection).rejects.toThrow('500');
   });
+
+  describe('relay rejections', () => {
+    const rejection = (status: number, details?: string) => ({
+      ok: false,
+      status,
+      headers: { get: (name: string) => (name.toLowerCase() === 'x-error-details' ? details ?? null : null) },
+    });
+
+    it('carries X-Error-Details from the relay on the thrown error', async () => {
+      global.fetch = jest.fn().mockResolvedValue(rejection(400, 'Sender storage quota exceeded'));
+
+      const relay = new Relay(testRelayURL);
+      await expect(relay.openConnection()).rejects.toMatchObject({
+        name: 'GlowNetworkError',
+        status: 400,
+        details: 'Sender storage quota exceeded',
+        message: 'GlowNetworkError status: 400 (Sender storage quota exceeded)',
+      });
+    });
+
+    it('keeps details undefined and the message unchanged when the header is absent', async () => {
+      global.fetch = jest.fn().mockResolvedValue(rejection(429));
+
+      const relay = new Relay(testRelayURL);
+      await expect(relay.openConnection()).rejects.toMatchObject({
+        name: 'GlowNetworkError',
+        status: 429,
+        details: undefined,
+        message: 'GlowNetworkError status: 429',
+      });
+    });
+  });
 });

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -203,7 +203,9 @@ export class Relay {
           this.clearSession();
           this.clearToken();
         }
-        throw new GlowNetworkError(response.status);
+        // the relay names safe-to-reveal rejection reasons in this header;
+        // reading it cross-origin requires the relay to expose it via CORS
+        throw new GlowNetworkError(response.status, response.headers.get('x-error-details') ?? undefined);
       }
       return await response.text();
     } catch (err: unknown) {


### PR DESCRIPTION
The relay reports safe-to-reveal rejection reasons (a full destination mailbox, an exceeded per-sender storage quota) in the `X-Error-Details` response header. Glow used to drop the header, so callers only got a status code. In practice that made a quota rejection indistinguishable from a broken session: a client that treats every 400 as a stale session responds with a clear-session-and-reconnect loop, burning the relay's rate-limit budget along the way.

Change:

- `GlowNetworkError` gets an optional `details` field, filled from `X-Error-Details` when the relay rejects a request. The error message becomes `GlowNetworkError status: 400 (Sender storage quota exceeded)` when details are present and keeps the exact old shape when they are absent, so existing message-based grouping only improves where the relay actually says something.
- No behavior change otherwise; relays that do not send the header work as before.

Note for the relay side: reading the header cross-origin needs `Access-Control-Expose-Headers: X-Error-Details` from the relay.

Tests: two new specs (details captured, absent header keeps old message); full suite 128/128, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
