### PR TITLE
Carry relay Retry-After on GlowNetworkError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glow.ts",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glow.ts",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "async-mutex": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glow.ts",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "displayName": "Glow.ts",
   "description": "Client library for interacting with Zax Cryptographic Relay Servers",
   "keywords": [

--- a/src/relay/network-error.ts
+++ b/src/relay/network-error.ts
@@ -8,8 +8,8 @@ export class GlowNetworkError extends Error {
    * considers safe to reveal (e.g. a full mailbox or an exceeded storage quota)
    * carry a specific message the caller can branch on.
    * @param retryAfter seconds until the relay accepts requests from this sender
-   * again, from the `Retry-After` response header on a 429. Undefined when the
-   * relay doesn't send the header.
+   * again, from the `Retry-After` response header on a 429. Zero means a retry
+   * is acceptable immediately. Undefined when the relay doesn't send the header.
    */
   constructor(public status: number|undefined, public details?: string, public retryAfter?: number) {
     super(details ? `GlowNetworkError status: ${status} (${details})` : `GlowNetworkError status: ${status}`);

--- a/src/relay/network-error.ts
+++ b/src/relay/network-error.ts
@@ -7,8 +7,11 @@ export class GlowNetworkError extends Error {
    * Most relay rejections share one generic text on purpose; conditions the relay
    * considers safe to reveal (e.g. a full mailbox or an exceeded storage quota)
    * carry a specific message the caller can branch on.
+   * @param retryAfter seconds until the relay accepts requests from this sender
+   * again, from the `Retry-After` response header on a 429. Undefined when the
+   * relay doesn't send the header.
    */
-  constructor(public status: number|undefined, public details?: string) {
+  constructor(public status: number|undefined, public details?: string, public retryAfter?: number) {
     super(details ? `GlowNetworkError status: ${status} (${details})` : `GlowNetworkError status: ${status}`);
   }
 }

--- a/src/relay/relay.spec.ts
+++ b/src/relay/relay.spec.ts
@@ -23,10 +23,16 @@ describe('Relay', () => {
   });
 
   describe('relay rejections', () => {
-    const rejection = (status: number, details?: string) => ({
+    const rejection = (status: number, details?: string, retryAfter?: string) => ({
       ok: false,
       status,
-      headers: { get: (name: string) => (name.toLowerCase() === 'x-error-details' ? details ?? null : null) },
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() === 'x-error-details') return details ?? null;
+          if (name.toLowerCase() === 'retry-after') return retryAfter ?? null;
+          return null;
+        },
+      },
     });
 
     it('carries X-Error-Details from the relay on the thrown error', async () => {
@@ -49,7 +55,30 @@ describe('Relay', () => {
         name: 'GlowNetworkError',
         status: 429,
         details: undefined,
+        retryAfter: undefined,
         message: 'GlowNetworkError status: 429',
+      });
+    });
+
+    it('carries Retry-After delta-seconds from the relay on the thrown error', async () => {
+      global.fetch = jest.fn().mockResolvedValue(rejection(429, undefined, '61'));
+
+      const relay = new Relay(testRelayURL);
+      await expect(relay.openConnection()).rejects.toMatchObject({
+        name: 'GlowNetworkError',
+        status: 429,
+        retryAfter: 61,
+      });
+    });
+
+    it('ignores a Retry-After value that is not delta-seconds', async () => {
+      global.fetch = jest.fn().mockResolvedValue(rejection(429, undefined, 'Wed, 21 Oct 2026 07:28:00 GMT'));
+
+      const relay = new Relay(testRelayURL);
+      await expect(relay.openConnection()).rejects.toMatchObject({
+        name: 'GlowNetworkError',
+        status: 429,
+        retryAfter: undefined,
       });
     });
   });

--- a/src/relay/relay.spec.ts
+++ b/src/relay/relay.spec.ts
@@ -71,6 +71,17 @@ describe('Relay', () => {
       });
     });
 
+    it('carries a zero Retry-After as a valid value', async () => {
+      global.fetch = jest.fn().mockResolvedValue(rejection(429, undefined, '0'));
+
+      const relay = new Relay(testRelayURL);
+      await expect(relay.openConnection()).rejects.toMatchObject({
+        name: 'GlowNetworkError',
+        status: 429,
+        retryAfter: 0,
+      });
+    });
+
     it('ignores a Retry-After value that is not delta-seconds', async () => {
       global.fetch = jest.fn().mockResolvedValue(rejection(429, undefined, 'Wed, 21 Oct 2026 07:28:00 GMT'));
 
@@ -80,6 +91,19 @@ describe('Relay', () => {
         status: 429,
         retryAfter: undefined,
       });
+    });
+
+    it('ignores Retry-After spellings outside the decimal-integer form', async () => {
+      for (const value of ['1.5', '1e3', '0x10', '-5']) {
+        global.fetch = jest.fn().mockResolvedValue(rejection(429, undefined, value));
+
+        const relay = new Relay(testRelayURL);
+        await expect(relay.openConnection()).rejects.toMatchObject({
+          name: 'GlowNetworkError',
+          status: 429,
+          retryAfter: undefined,
+        });
+      }
     });
   });
 });

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -203,9 +203,13 @@ export class Relay {
           this.clearSession();
           this.clearToken();
         }
-        // the relay names safe-to-reveal rejection reasons in this header;
-        // reading it cross-origin requires the relay to expose it via CORS
-        throw new GlowNetworkError(response.status, response.headers.get('x-error-details') ?? undefined);
+        // the relay names safe-to-reveal rejection reasons in X-Error-Details
+        // and the seconds until a rate-limited sender may retry in Retry-After;
+        // reading either cross-origin requires the relay to expose it via CORS
+        const retryAfter = Number(response.headers.get('retry-after'));
+        throw new GlowNetworkError(response.status, response.headers.get('x-error-details') ?? undefined,
+          // delta-seconds only: an absent header or an HTTP-date form is ignored
+          Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : undefined);
       }
       return await response.text();
     } catch (err: unknown) {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -206,10 +206,11 @@ export class Relay {
         // the relay names safe-to-reveal rejection reasons in X-Error-Details
         // and the seconds until a rate-limited sender may retry in Retry-After;
         // reading either cross-origin requires the relay to expose it via CORS
-        const retryAfter = Number(response.headers.get('retry-after'));
+        const retryAfter = response.headers.get('retry-after');
         throw new GlowNetworkError(response.status, response.headers.get('x-error-details') ?? undefined,
-          // delta-seconds only: an absent header or an HTTP-date form is ignored
-          Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : undefined);
+          // strict delta-seconds (1*DIGIT): zero is valid ("retry now"); the
+          // HTTP-date form and any other spelling are ignored
+          retryAfter !== null && /^\d+$/.test(retryAfter) ? parseInt(retryAfter, 10) : undefined);
       }
       return await response.text();
     } catch (err: unknown) {


### PR DESCRIPTION
Zax relays rate-limit commands per sender identity and reply with 429 when the budget for the current window is spent. The relay now names the seconds until the window reopens in a standard `Retry-After` response header, so a client can schedule its retry for the moment the budget is fresh instead of probing on a fixed timer.

This PR carries that value on `GlowNetworkError` as a new optional `retryAfter` field (whole seconds), the same way `X-Error-Details` is carried in `details`:

- only the delta-seconds form is accepted; an absent header or the HTTP-date form leaves the field `undefined`;
- reading the header cross-origin requires the relay to list it in `Access-Control-Expose-Headers`, which paired relay-side support does;
- no behavior change for callers that ignore the new field.

Version bumped to 1.2.1.

## Tests

`relay rejections` spec block extended: carries delta-seconds on a 429, ignores non-numeric values, stays `undefined` when the header is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
